### PR TITLE
Solves Issue#24 and fixes core properties being set on TaskDialog

### DIFF
--- a/source/WindowsAPICodePack/Core.Shared/Dialogs/TaskDialogs/TaskDialog.cs
+++ b/source/WindowsAPICodePack/Core.Shared/Dialogs/TaskDialogs/TaskDialog.cs
@@ -81,7 +81,8 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
             set
             {
                 // Set local value, then update native dialog if showing.
-                if (NativeDialogShowing) nativeDialog.UpdateText(text = value);
+                text = value;
+                if (NativeDialogShowing) nativeDialog.UpdateText(value);
             }
         }
 
@@ -96,7 +97,8 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
             set
             {
                 // Set local value, then update native dialog if showing.
-                if (NativeDialogShowing) nativeDialog.UpdateInstruction(instructionText = value);
+                instructionText = value;
+                if (NativeDialogShowing) nativeDialog.UpdateInstruction(value);
             }
         }
 
@@ -126,7 +128,8 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
             set
             {
                 // Set local value, then update native dialog if showing.
-                if (NativeDialogShowing) nativeDialog.UpdateFooterText(footerText = value);
+                footerText = value;
+                if (NativeDialogShowing) nativeDialog.UpdateFooterText(value);
             }
         }
 
@@ -156,7 +159,8 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
             set
             {
                 // Set local value, then update native dialog if showing.
-                if (NativeDialogShowing) nativeDialog.UpdateExpandedText(detailsExpandedText = value);
+                detailsExpandedText = value;
+                if (NativeDialogShowing) nativeDialog.UpdateExpandedText(value);
             }
         }
 
@@ -231,7 +235,8 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
             set
             {
                 // Set local value, then update native dialog if showing.
-                if (NativeDialogShowing) nativeDialog.UpdateMainIcon(icon = value);
+                icon = value;
+                if (NativeDialogShowing) nativeDialog.UpdateMainIcon(value);
             }
         }
 
@@ -246,7 +251,8 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
             set
             {
                 // Set local value, then update native dialog if showing.
-                if (NativeDialogShowing) nativeDialog.UpdateFooterIcon(footerIcon = value);
+                footerIcon = value;
+                if (NativeDialogShowing) nativeDialog.UpdateFooterIcon(value);
             }
         }
 
@@ -737,7 +743,8 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
 
         private void ApplySupplementalSettings(in NativeTaskDialogSettings settings)
         {
-            if (progressBar?.State != TaskDialogProgressBarState.Marquee)
+            if (progressBar != null &&
+                progressBar.State != TaskDialogProgressBarState.Marquee)
             {
                 settings.ProgressBarMinimum = progressBar.Minimum;
                 settings.ProgressBarMaximum = progressBar.Maximum;

--- a/source/WindowsAPICodePack/Core.Shared/Interop/NativeTaskDialog.cs
+++ b/source/WindowsAPICodePack/Core.Shared/Interop/NativeTaskDialog.cs
@@ -520,7 +520,7 @@ namespace Microsoft.WindowsAPICodePack.Dialogs
             foreach (Win32Native.Dialogs.TaskDialog.TaskDialogButton button in structs)
             {
                 Marshal.StructureToPtr(button, currentPtr, false);
-                currentPtr = (IntPtr)(is64Bit ? currentPtr.ToInt64() : currentPtr.ToInt32() + Marshal.SizeOf(button));
+                currentPtr = (IntPtr)((is64Bit ? currentPtr.ToInt64() : currentPtr.ToInt32()) + Marshal.SizeOf(button));
             }
 
             return initialPtr;


### PR DESCRIPTION
- ApplySupplementalSettings - Needs null check before comparison, Fixes Issue #24 
- FooterIcon/Icon/DetailsExpandedText/FooterText/InstructionText/Text - Needs to be set regardless of NativeDialogShowing, or it will not be set on TaskDialog.Show()